### PR TITLE
no_refresh, archive and others 

### DIFF
--- a/lib/Message/Passing/Output/ElasticSearch.pm
+++ b/lib/Message/Passing/Output/ElasticSearch.pm
@@ -80,10 +80,6 @@ sub consume {
     $date ||= DT->from_epoch(epoch => time());
     my $type = $data->{__CLASS__} || 'unknown';
     my $index_name = 'logstash-' . $date->year . '.' . sprintf("%02d", $date->month) . '.' . sprintf("%02d", $date->day);
-    if ($index_name !~ /logstash-2012/) {
-        use Data::Dumper;
-        die "BUG - We generated a message from before 2012 - Payload " . Dumper($data);
-    }
     $self->_indexes->{$index_name} = 1;
     my $to_queue = {
         type => $type,

--- a/lib/Message/Passing/Output/ElasticSearch.pm
+++ b/lib/Message/Passing/Output/ElasticSearch.pm
@@ -33,6 +33,7 @@ has _es => (
             transport => "aehttp",
             servers => $self->elasticsearch_servers,
             timeout => 30,
+            no_refresh => 1,
  #           trace_calls => 1,
         );
     }

--- a/lib/Message/Passing/Output/ElasticSearch.pm
+++ b/lib/Message/Passing/Output/ElasticSearch.pm
@@ -198,7 +198,7 @@ has _archive_timer => (
         weaken($self);
         my $time = 60 * 60 * 24; # Every day
         AnyEvent->timer(
-            after => $time,
+            after => 60, # delay 1 hour to start first loop
             interval => $time,
             cb => sub { $self->_archive_index() },
         );


### PR DESCRIPTION
add no_refresh = , which allow to use elaticsearch as remote server
add archive to close and delete old log indexes 
and other fixes
