### PR TITLE
Output formatters and raw format

### DIFF
--- a/README
+++ b/README
@@ -48,6 +48,10 @@ METHODS
     A required attribute for the ElasticSearch server FQDNs or IP addresses
     including the port which normally is 9200.
 
+  format
+    Mechanism to use to format the consumed message before sending it on to
+    ElasticSearch. Options are "logstash" and "raw".
+
   verbose
     A boolean attribute that defaults to true if STDIN is opened to a tty.
 


### PR DESCRIPTION
I don't want to use the logstash format, but I don't want to write my own output module either - the whole queuing and flushing stuff is good! So this lets you choose to either do the logstash munging, or just send the data through (mostly) as-is.

I think this isn't the right way to do it. Better would probably be to have a bunch of M::P::O::ES::Formatter::\* modules and let the caller choose one, so we can have more on CPAN. But I don't actually need that and to do it right would mean learning more Moose than I have time for right now. So feel free to drop this on the floor.
