### PR TITLE
Allow log closing and deletion to be tuned

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,4 @@
+  - Allow log closing and deletion to be adjusted.
   - Add documentation for the ElasticSearch document format
 
 0.004


### PR DESCRIPTION
Allow log closing and deletion to be tuned.

The housekeeping option is useful if you want to have multiple workers indexing data into ElasticSearch.
